### PR TITLE
Fix: wrong imports for large model

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Combine simple caption with tag caption and save to output files
 ## Huggingface model
 Model should be automatically downloaded the first time when you use the node. In any case that didn't happen, you can manually download it.
 [MiaoshouAI/Florence-2-base-PromptGen-v1.5](https://huggingface.co/MiaoshouAI/Florence-2-base-PromptGen-v1.5)
-The downloaded model will be placed under`ComfyUI/LLM` folder
+The downloaded model will be placed under`ComfyUI/models/LLM` folder
 If you want to use a new version of PromptGen, you can simply delete the model folder and relaunch the ComfyUI workflow. It will auto download the model for you.
 
 ## Windows Tagger Program

--- a/nodes.py
+++ b/nodes.py
@@ -135,8 +135,12 @@ class Tagger:
         sys.path.append(model_path)
 
         # Import the Florence modules
-        from florence2_base_ft.modeling_florence2 import Florence2ForConditionalGeneration
-        from florence2_base_ft.configuration_florence2 import Florence2Config
+        if model == 'promptgen_large_v1.5':
+            from florence_2_large.modeling_florence2 import Florence2ForConditionalGeneration
+            from florence_2_large.configuration_florence2 import Florence2Config
+        else:
+            from florence2_base_ft.modeling_florence2 import Florence2ForConditionalGeneration
+            from florence2_base_ft.configuration_florence2 import Florence2Config
 
         # Load the model configuration
         model_config = Florence2Config.from_pretrained(model_path)


### PR DESCRIPTION
Fix for: #21 #20 #18 

The "No module named 'florence2_base_ft'" error is due to the wrong import name. On huggingface, the folder in the large model repo is called 'florence-2-large'. Python imports cannot have dashes. The folder on hugging face should be updated to 'florence_2_large' before this PR is merged.
![CleanShot 2024-09-28 at 22 40 01@2x](https://github.com/user-attachments/assets/a3593f2c-8b07-4242-82a0-20dd22876297)

This will allow the large model to be used without having to download the normal model first. 

Note: If anyone needs to fix this before this PR is merged, change the `ComfyUI/models/LLM/Florence-2-large-PromptGen-v1.5/florence-2-large` folder to `ComfyUI/models/LLM/Florence-2-large-PromptGen-v1.5/florence2_base_ft`